### PR TITLE
Recommended and security considerations

### DIFF
--- a/.github/workflows/xml2rfc.yml
+++ b/.github/workflows/xml2rfc.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           mkdir output
 
-      - name: build htm
+      - name: build html
         uses: addnab/docker-run-action@v3
         with:
           image: paulej/rfctools

--- a/.github/workflows/xml2rfc.yml
+++ b/.github/workflows/xml2rfc.yml
@@ -1,0 +1,40 @@
+name: Build RFC
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+
+      - name: cache xml2rfc cache
+        id: xml2rfc-cache
+        uses: actions/cache@v2
+        with:
+          key: xml2rfc-cache
+          path: .cache-xml2rfc
+
+      - name: create output dir
+        run: |
+          mkdir output
+
+      - name: build htm
+        uses: addnab/docker-run-action@v3
+        with:
+          image: paulej/rfctools
+          options: -v ${{ github.workspace }}:/rfc -v ${{ github.workspace }}/.cache-xml2rfc:/var/cache/xml2rfc -w /rfc 
+          run: |
+            xml2rfc -p output --text --html draft-spaghetti-sidrops-cms-signing-time.xml
+      
+      - name: Archive output
+        uses: actions/upload-artifact@v2
+        with:
+          name: xml2rfc-output
+          path: output/
+

--- a/draft-spaghetti-sidrops-cms-signing-time.xml
+++ b/draft-spaghetti-sidrops-cms-signing-time.xml
@@ -220,7 +220,9 @@
   </section>
 
   <section title="Security Considerations">
--      This document has no Security Considerations.
+    <t>
+      This document has no Security Considerations.
+    </t>
   </section>
 
   <section title="IANA Considerations">

--- a/draft-spaghetti-sidrops-cms-signing-time.xml
+++ b/draft-spaghetti-sidrops-cms-signing-time.xml
@@ -106,6 +106,9 @@
       <t>
         When serializing RPKI Signed Objects to a filesystem hierarchy for RSYNC consumption, the mod-time of the file containing the Signed Object SHOULD be set to the CMS signing-time contained within the Signed Object.
       </t>
+      <t>
+        In general, actors are limited to changing objects in the publication point for a CA under their control. In some situations (i.e. creating an object at a parent CA through automated means), actors may be able to create/update/delete objects in a shared publication point. Using a filename derived from the one-time use EE certificate's public key prevents the publication of Signed Objects at the same URL and mod-time.
+      </t>
     </section>
     <section title="Guidance for Relying Parties" anchor="rpguidance">
       <t>
@@ -217,15 +220,7 @@
   </section>
 
   <section title="Security Considerations">
-    <t>
-      Two reasons for Publishers not using the signing time as mod-time were discussed. First of all, code that writes a repository structure now needs to parse ASN.1/x509 objects, increasing complexity.
-    </t>
-    <t>
-      Second, an actor could cause the publication of multiple objects at the same path with the same signing time (e.g. by causing multiple objects to be published during the same second). The repository spooling approach described in [XREF] may exacerbate this issue. Depending on the sequence of events observed by an RP, this may result in a failed fetch.
-    </t>
-    <t>
-      Publishers implementing [this document] should weigh the peak data transfer saved on fallback from RRDP to rsync by writing a consistent mod-time against this unlikely but not purely theoretical situation.
-    </t>
+-      This document has no Security Considerations.
   </section>
 
   <section title="IANA Considerations">

--- a/draft-spaghetti-sidrops-cms-signing-time.xml
+++ b/draft-spaghetti-sidrops-cms-signing-time.xml
@@ -104,7 +104,7 @@
     </t>
     <section title="Guidance for Publishers">
       <t>
-        When serializing RPKI Signed Objects to a filesystem hierarchy for RSYNC consumption, the mod-time of the file containing the Signed Object MUST be set to the CMS signing-time contained within the Signed Object.
+        When serializing RPKI Signed Objects to a filesystem hierarchy for RSYNC consumption, the mod-time of the file containing the Signed Object SHOULD be set to the CMS signing-time contained within the Signed Object.
       </t>
     </section>
     <section title="Guidance for Relying Parties" anchor="rpguidance">
@@ -163,11 +163,10 @@
 
   <section title="Considerations and Alternative Approaches">
     <t>
-      A slightly different approach that has been suggested is to normalize file mod-times based on the Signed Object's embedded End-Entity (EE) X.509 notBefore timestamp value.
-      A downside of that approach is that CAs might backdate the notBefore timestamp to increase the validity window of the Signed Object, which in turn decreases insight for RPKI operators as to when exactly the Signed Object purportedly came into existence.
+      A slightly different approach that has been suggested is to normalize file mod-times based on the Signed Object's embedded End-Entity (EE) X.509 notBefore timestamp value. A downside of this approach is that objects from CAs not using one-time use EE certificates, per section 5.1.1 of <xref target="RFC9286" /> would result in multiple objects singed at different points in time with the same mod-times.
     </t>
     <t>
-      Along similar lines, the notBefore timestamp may be set in the future.  Setting the mod-time of a file to a future date may be unintuitive for users, and some programs (e.g. make) will warn on encountering files with such mod-times.
+      Additionally, CAs might backdate the notBefore timestamp to increase the validity window of the Signed Object, which in turn decreases insight for RPKI operators as to when exactly the Signed Object purportedly came into existence. Along similar lines, the notBefore timestamp may be set in the future.  Setting the mod-time of a file to a future date may be unintuitive for users, and some programs (e.g. make) will warn on encountering files with such mod-times.
     </t>
     <t>
       There is also an increased chance of two distinct objects published to the same path having the same mod-time and filesize under this approach, due to CAs setting the notBefore timestamp to some stable value for a given object and reissuance often not changing the file size (e.g. where a prefix or a max-length value is changed in a ROA).  In such a situation, if the receiver has the first copy of a file, RSYNC retrieval will skip the second copy of the file, and the synchronization operation for the associated repository will result in a "failed fetch", per section 6.6 of <xref target="RFC9286" />, due to an inconsistency between the file's hash and the hash listed in the associated manifest.  That in turn necessitates further retrieval operations on the part of the receiver.  The chance of two distinct objects being issued with the same mod-time and filesize when CMS signing-time is used to set the mod-time is much smaller, since it requires that those distinct objects be issued in very close succession.
@@ -219,7 +218,13 @@
 
   <section title="Security Considerations">
     <t>
-      This document has no Security Considerations.
+      Two reasons for Publishers not using the signing time as mod-time were discussed. First of all, code that writes a repository structure now needs to parse ASN.1/x509 objects, increasing complexity.
+    </t>
+    <t>
+      Second, an actor could cause the publication of multiple objects at the same path with the same signing time (e.g. by causing multiple objects to be published during the same second). The repository spooling approach described in [XREF] may exacerbate this issue. Depending on the sequence of events observed by an RP, this may result in a failed fetch.
+    </t>
+    <t>
+      Publishers implementing [this document] should weigh the peak data transfer saved on fallback from RRDP to rsync by writing a consistent mod-time against this unlikely but not purely theoretical situation.
     </t>
   </section>
 


### PR DESCRIPTION
I tried to write down my thinking. Main points:
  * definitely prefer signing-time over notBefore because of CAs not doing single-use EE certs
  * I think as is the MUST for Publishers is a bit strong